### PR TITLE
Fix permission for mitmproxy directory

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,12 @@ FROM alpine:3.4
 ENV LANG=en_US.UTF-8
 
 COPY requirements.txt /tmp/requirements.txt
-RUN apk add --no-cache \
+
+# add our user first to make sure the ID get assigned consistently,
+# regardless of whatever dependencies get added
+RUN addgroup -S mitmproxy && adduser -S -G mitmproxy mitmproxy \
+    && apk add --no-cache \
+        su-exec \
         git \
         g++ \
         libffi \
@@ -34,12 +39,12 @@ RUN apk add --no-cache \
         python3-dev \
         zlib-dev \
     && rm /tmp/requirements.txt \
-    && rm -rf ~/.cache/pip \
-    && adduser -u 7799 -D mitmproxy
+    && rm -rf ~/.cache/pip
 
-USER mitmproxy
-RUN mkdir /home/mitmproxy/.mitmproxy
 VOLUME /home/mitmproxy/.mitmproxy
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 8080 8081
 CMD ["mitmproxy"]

--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
+
+if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
+        mkdir -p "$MITMPROXY_PATH"
+        chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"
+
+        su-exec mitmproxy "$@"
+else
+        exec "$@"
+fi


### PR DESCRIPTION
Fix issue https://github.com/mitmproxy/docker-releases/issues/6.

This approach is the same used by official Docker images such as mysql and postgres.

Running the container with any mitmproxy tool it will set the required permissions for
mitmproxy directory and run the process also with the mitmproxy user.

Otherwise it will run the passed arg with the root user. Which allows the user to
test the container with any command. Just will not set the directory permission running this way.