### PR TITLE
Enable setting user and group via ENV variables

### DIFF
--- a/alpine/docker-entrypoint.sh
+++ b/alpine/docker-entrypoint.sh
@@ -2,12 +2,14 @@
 set -e
 
 MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
+MITMPROXY_USER=${MITMPROXY_USER:-mitmproxy}
+MITMPROXY_GROUP=${MITMPROXY_GROUP:-mitmproxy}
 
 if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
         mkdir -p "$MITMPROXY_PATH"
-        chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"
+        chown -R $MITMPROXY_USER:$MITMPROXY_GROUP "$MITMPROXY_PATH"
 
-        su-exec mitmproxy "$@"
+        su-exec $MITMPROXY_USER "$@"
 else
-        exec "$@"
+        su-exec "$@"
 fi


### PR DESCRIPTION
In trying to use the reverse-proxy command with a volume (to pull out the data) I ran into the problem that the volume will implicitly be owned by `root`, and have `drwxr-xr-x`. Since this docker is changing over to a different user that is not going to be able to write there.

This change allows me to change the user it is being run as, so I can set this.

An alternative would be to remove all of that, and instead just rely on the [Docker `USER` setting](https://docs.docker.com/engine/reference/run/#user), which would allow people to do the same thing from `docker-compose` files. I would be happy to trash this and submit that.